### PR TITLE
Refine Ciel scraper and workflow

### DIFF
--- a/.github/workflows/scrape_ciel.yml
+++ b/.github/workflows/scrape_ciel.yml
@@ -1,0 +1,36 @@
+name: Scrape Ciel with Playwright
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */3 * * *'
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements.txt
+          python -m playwright install
+
+      - name: Run ciel scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+        run: python ciel_scraper.py
+
+      - name: Upload page debug HTML
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ciel_page_debug
+          path: ciel_page_debug.html

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Pokeca Scraper
+
+This repository contains several scrapers for various card shop sites. A GitHub
+Actions workflow automatically runs the Ciel scraper on a schedule.
+
+[![.github/workflows/scrape_ciel.yml](https://github.com/kuuhaku1102/pokeca-scraper/actions/workflows/scrape_ciel.yml/badge.svg)](https://github.com/kuuhaku1102/pokeca-scraper/actions/workflows/scrape_ciel.yml)

--- a/ciel_scraper.py
+++ b/ciel_scraper.py
@@ -1,0 +1,113 @@
+import base64
+import os
+from urllib.parse import urlparse
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+
+def strip_query(url: str) -> str:
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+
+
+# --- Google Sheets 認証 ---
+with open("credentials.json", "w") as f:
+    f.write(base64.b64decode(os.environ["GSHEET_JSON"]).decode("utf-8"))
+
+scopes = ["https://www.googleapis.com/auth/spreadsheets", "https://www.googleapis.com/auth/drive"]
+creds = Credentials.from_service_account_file("credentials.json", scopes=scopes)
+gc = gspread.authorize(creds)
+spreadsheet = gc.open_by_url("https://docs.google.com/spreadsheets/d/11agq4oxQxT1g9ZNw_Ad9g7nc7PvytHr1uH5BSpwomiE/edit")
+sheet = spreadsheet.worksheet("その他")
+
+# --- 既存データ取得（画像URLで重複チェック） ---
+existing_data = sheet.get_all_values()[1:]
+existing_image_urls = {strip_query(row[1]) for row in existing_data if len(row) > 1}
+
+results = []
+html = ""
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+    page = browser.new_page()
+    print("🔍 ciel-toreca スクレイピング開始...")
+
+    try:
+        page.goto("https://ciel-toreca.com/", timeout=60000, wait_until="networkidle")
+    except Exception as e:
+        print(f"🛑 ページ読み込みエラー: {str(e)}")
+        html = page.content()
+        browser.close()
+        exit()
+
+    html = page.content()
+    # 対象のガチャ要素を抽出
+    items = page.evaluate(
+        """
+        () => {
+            const cards = document.querySelectorAll(
+                'div.cursor-pointer a[href^="/gacha/"]'
+            );
+            return Array.from(cards).map(card => {
+                const img = card.querySelector('img');
+                const image = img ? (img.dataset.src || img.src) : '';
+
+                let title = '';
+                const titleEl = card.querySelector('div.text-yellow-400') || card.querySelector('div.pt-2.5');
+                if (titleEl) {
+                    title = titleEl.textContent.trim();
+                } else if (img) {
+                    title = img.alt || img.title || '';
+                }
+
+                const ptEl = card.querySelector('.flex.items-center span.font-semibold');
+                const pt = ptEl ? ptEl.textContent.trim() : '';
+
+                return { title, image, url: card.href, pt };
+            });
+        }
+        """
+    )
+
+    browser.close()
+
+    if not items:
+        print("📭 画像情報が取得できませんでした。")
+    else:
+        print(f"📦 {len(items)} 件の画像を取得")
+        for item in items:
+            title = item["title"].strip()
+            image_url = item["image"]
+            detail_url = item["url"]
+            pt = item.get("pt", "").strip()
+
+            if image_url.startswith("/"):
+                image_url = "https://ciel-toreca.com" + image_url
+            if detail_url.startswith("/"):
+                detail_url = "https://ciel-toreca.com" + detail_url
+
+            norm_url = strip_query(image_url)
+            if norm_url in existing_image_urls:
+                print(f"⏭ スキップ（重複）: {title}")
+                continue
+
+            print(f"✅ 取得: {title}")
+            results.append([title, image_url, detail_url, pt])
+
+# --- スプレッドシートに追記 ---
+if results:
+    next_row = len(existing_data) + 2
+    try:
+        sheet.update(range_name=f"A{next_row}:D{next_row + len(results) - 1}", values=results)
+        print(f"📥 {len(results)} 件追記完了")
+    except Exception as e:
+        print(f"❌ スプレッドシート書き込み失敗: {str(e)}")
+else:
+    print("📭 新規データなし")
+
+# --- デバッグHTML保存 ---
+if html:
+    with open("ciel_page_debug.html", "w", encoding="utf-8") as f:
+        f.write(html)


### PR DESCRIPTION
## Summary
- add workflow `scrape_ciel.yml` to run the scraper on schedule
- refine `ciel_scraper.py` to capture title, image URL, page URL and PT
- write 4 columns to the spreadsheet
- add README with workflow badge

## Testing
- `python -m py_compile ciel_scraper.py`
- `python -m compileall -q .`
