### PR TITLE
Fix Playwright launch for dopa scraper

### DIFF
--- a/scrape_dopa_to_sheets.py
+++ b/scrape_dopa_to_sheets.py
@@ -22,21 +22,31 @@ existing_image_urls = {row[1] for row in existing_data if len(row) > 1}
 results = []
 
 with sync_playwright() as p:
-    browser = p.chromium.launch(headless=True)
-    page = browser.new_page()
+    browser = p.chromium.launch(headless=True, args=["--no-sandbox", "--disable-dev-shm-usage"])
+    page = browser.new_page(
+        user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0 Safari/537.36"
+    )
     print("🔍 dopa スクレイピング開始...")
-    page.goto("https://dopa-game.jp/", timeout=60000)
+    page.goto("https://dopa-game.jp/", timeout=60000, wait_until="networkidle")
 
     try:
-        page.wait_for_selector("div.css-1flrjkp", timeout=60000)
-    except Exception:
-        print("🛑 要素が読み込まれませんでした。")
+        page.wait_for_selector("a[href^='/pokemon/gacha/'] img", timeout=60000)
+    except Exception as e:
+        print("🛑 要素が読み込まれませんでした。", e)
+        page.screenshot(path="dopa_debug.png")
+        with open("dopa_debug.html", "w", encoding="utf-8") as f:
+            f.write(page.content())
         browser.close()
         exit()
 
     html = page.content()
     soup = BeautifulSoup(html, "html.parser")
     cards = soup.select("div.css-1flrjkp")
+    if not cards:
+        cards = {a.find_parent("div") for a in soup.select("a[href^='/pokemon/gacha/']")}
+        cards = list(cards)
 
     for card in cards:
         a_tag = card.select_one("a.css-4g6ai3")


### PR DESCRIPTION
## Summary
- tweak Playwright launch flags and set user agent
- capture screenshot and html on failure
- fall back to anchor-based card selection when CSS class missing

## Testing
- `python -m py_compile scrape_dopa_to_sheets.py`
