### PR TITLE
Fix Playwright launch for dopa scraper

### DIFF
--- a/scrape_dopa_to_sheets.py
+++ b/scrape_dopa_to_sheets.py
@@ -22,32 +22,45 @@ existing_image_urls = {row[1] for row in existing_data if len(row) > 1}
 results = []
 
 with sync_playwright() as p:
-    browser = p.chromium.launch(headless=True)
-    page = browser.new_page()
+    browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+    page = browser.new_page(
+        user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+    )
     print("🔍 dopa スクレイピング開始...")
-    page.goto("https://dopa-game.jp/", timeout=60000)
+    page.goto("https://dopa-game.jp/", timeout=60000, wait_until="networkidle")
 
     try:
         page.wait_for_selector("div.css-1flrjkp", timeout=60000)
-    except Exception:
-        print("🛑 要素が読み込まれませんでした。")
+    except Exception as e:
+        print("🛑 要素が読み込まれませんでした。", e)
+        with open("dopa_debug.html", "w", encoding="utf-8") as f:
+            f.write(page.content())
+        page.screenshot(path="dopa_debug.png")
         browser.close()
         exit()
 
     html = page.content()
     soup = BeautifulSoup(html, "html.parser")
     cards = soup.select("div.css-1flrjkp")
+    fallback = False
+    if not cards:
+        cards = soup.select("a[href^='/pokemon/gacha/'] img")
+        fallback = True
 
     for card in cards:
-        a_tag = card.select_one("a.css-4g6ai3")
-        img_tag = a_tag.select_one("img") if a_tag else None
+        if fallback:
+            img_tag = card
+            a_tag = img_tag.find_parent("a")
+        else:
+            a_tag = card.select_one("a.css-4g6ai3")
+            img_tag = a_tag.select_one("img") if a_tag else None
 
         if not (a_tag and img_tag):
             continue
 
         title = img_tag.get("alt", "無題").strip()
-        image_url = img_tag["src"]
-        detail_url = a_tag["href"]
+        image_url = img_tag.get("src", "")
+        detail_url = a_tag.get("href", "") if a_tag else ""
 
         if image_url.startswith("/"):
             image_url = "https://dopa-game.jp" + image_url
@@ -55,15 +68,19 @@ with sync_playwright() as p:
             detail_url = "https://dopa-game.jp" + detail_url
 
         # ✅ PT数抽出（150だけ）
-        pt_tag = card.select_one("span.chakra-text.css-19bpybc")
-        pt_text = pt_tag.get_text(strip=True) if pt_tag else ""
+        if fallback:
+            pt_text = ""
+        else:
+            pt_tag = card.select_one("span.chakra-text.css-19bpybc")
+            pt_text = pt_tag.get_text(strip=True) if pt_tag else ""
 
         # 当たりカード画像をすべて取得
         atari_imgs = []
-        for atari_div in card.select('div.chakra-aspect-ratio.css-839f3u'):
-            img = atari_div.find('img')
-            if img and img.get('src'):
-                atari_imgs.append(img['src'])
+        if not fallback:
+            for atari_div in card.select('div.chakra-aspect-ratio.css-839f3u'):
+                img = atari_div.find('img')
+                if img and img.get('src'):
+                    atari_imgs.append(img['src'])
 
         # 画像URLをカンマ区切りで保存
         atari_imgs_str = ','.join(atari_imgs)


### PR DESCRIPTION
## Summary
- use `--no-sandbox` option when launching chromium
- wait for networkidle when loading page
- write page HTML on failure for easier debugging
- add a desktop user agent and screenshot on failure
- fall back to anchor-based parsing when main selector is missing

## Testing
- `python -m py_compile scrape_dopa_to_sheets.py`
