### PR TITLE
Add orikuji.com scraper

### DIFF
--- a/orikuji_scraper.py
+++ b/orikuji_scraper.py
@@ -1,0 +1,128 @@
+import os
+import base64
+from typing import List
+from urllib.parse import urljoin
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "https://orikuji.com/"
+SHEET_NAME = "その他"
+SPREADSHEET_URL = os.environ.get("SPREADSHEET_URL")
+
+
+def save_credentials() -> str:
+    """Decode GSHEET_JSON env and save to credentials.json."""
+    encoded = os.environ.get("GSHEET_JSON", "")
+    if not encoded:
+        raise RuntimeError("GSHEET_JSON environment variable is missing")
+    with open("credentials.json", "w") as f:
+        f.write(base64.b64decode(encoded).decode("utf-8"))
+    return "credentials.json"
+
+
+def get_sheet():
+    """Authorize gspread and return the 'その他' worksheet."""
+    creds_path = save_credentials()
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    client = gspread.authorize(creds)
+    if not SPREADSHEET_URL:
+        raise RuntimeError("SPREADSHEET_URL environment variable is missing")
+    spreadsheet = client.open_by_url(SPREADSHEET_URL)
+    return spreadsheet.worksheet(SHEET_NAME)
+
+
+def fetch_existing_urls(sheet) -> set:
+    """Return a set of already stored detail URLs."""
+    records = sheet.get_all_values()
+    urls = set()
+    for row in records[1:]:
+        if len(row) >= 3:
+            urls.add(row[2].strip())
+    return urls
+
+
+def scrape_orikuji(existing_urls: set) -> List[List[str]]:
+    """Scrape orikuji.com and return rows for new gacha items."""
+    rows: List[List[str]] = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        page = browser.new_page()
+        print("🔍 orikuji.com スクレイピング開始...")
+
+        try:
+            page.goto(BASE_URL, timeout=60000, wait_until="networkidle")
+            # スクロールしてLazyLoad画像を読み込み
+            page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+            page.wait_for_timeout(2000)
+            page.wait_for_selector("div.white-box img", timeout=60000)
+        except Exception as exc:
+            print(f"🛑 ページ読み込み失敗: {exc}")
+            browser.close()
+            return rows
+
+        items = page.evaluate(
+            """
+            () => {
+                const results = [];
+                document.querySelectorAll('div.white-box').forEach(box => {
+                    const link = box.querySelector('a[href*="/gacha/"]');
+                    const img = box.querySelector('img');
+                    if (!link || !img) return;
+                    const title = img.getAttribute('alt') || 'noname';
+                    const image =
+                        img.getAttribute('data-src') ||
+                        img.getAttribute('src') || '';
+                    const url = link.getAttribute('href') || '';
+                    const ptEl = box.querySelector('span.coin-area');
+                    const pt = ptEl ? ptEl.textContent.trim() : '';
+                    results.push({ title, image, url, pt });
+                });
+                return results;
+            }
+            """
+        )
+        browser.close()
+
+    for item in items:
+        detail_url = item.get("url", "").strip()
+        image_url = item.get("image", "").strip()
+        title = item.get("title", "noname").strip() or "noname"
+        pt_text = item.get("pt", "").strip()
+
+        if detail_url.startswith("/"):
+            detail_url = urljoin(BASE_URL, detail_url)
+        if image_url.startswith("/"):
+            image_url = urljoin(BASE_URL, image_url)
+
+        if detail_url in existing_urls:
+            print(f"⏭ スキップ（重複）: {title}")
+            continue
+
+        rows.append([title, image_url, detail_url, pt_text])
+        existing_urls.add(detail_url)
+
+    return rows
+
+
+def main() -> None:
+    sheet = get_sheet()
+    existing_urls = fetch_existing_urls(sheet)
+    rows = scrape_orikuji(existing_urls)
+    if not rows:
+        print("📭 新規データなし")
+        return
+    try:
+        sheet.append_rows(rows, value_input_option="USER_ENTERED")
+        print(f"📥 {len(rows)} 件追記完了")
+    except Exception as exc:
+        print(f"❌ 書き込みエラー: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- support scraping gacha info from orikuji.com
- append unique data to "その他" sheet using environment credentials
- handle lazy loading and `data-src` images

## Testing
- `python -m py_compile orikuji_scraper.py`
