### PR TITLE
I've added `moshoripa_scraper.py` for scraping gacha data.

### DIFF
--- a/ai_prompt.txt
+++ b/ai_prompt.txt
@@ -1,0 +1,58 @@
+The following Python script, `moshoripa_scraper.py`, is designed to scrape data from the website moshoripa.com and append new findings to a specified Google Sheet.
+
+**Objective:**
+The primary goal of this script is to automate the collection of product information (specifically "gacha" items) from moshoripa.com. It identifies items, extracts relevant details, and then adds any newly found items to a Google Spreadsheet, ensuring no duplicate entries based on the item's detail URL.
+
+**Target URL:**
+The script targets the main page of the website: `https://moshoripa.com/`
+
+**Data to Scrape per Item:**
+For each item found on the page (typically represented by a "gacha card" element), the script extracts the following information:
+1.  **Title**: The name or title of the item. This is primarily sourced from the text content of an `a.gacha-link` element. If this is empty or insufficient, it falls back to the `alt` text of the item's image (`img` tag within `a.gacha-link`). A default "No title" is used if neither is found.
+2.  **Image URL**: The direct URL to the item's image. This is extracted from the `src` attribute of an `img` tag found within `a.gacha-link`.
+3.  **Detail URL**: The URL leading to the item's specific detail page. This is extracted from the `href` attribute of the `a.gacha-link` element.
+4.  **PT (Points)**: The point value associated with the item. This is extracted from the text content of a `span.font-size-xl` element, which is itself within a `div.gacha-price` element. Defaults to '0' if not found.
+
+**Key Technologies Used:**
+*   **Python**: The core programming language.
+*   **Playwright**: For web browser automation. It's used to navigate to the target URL, interact with the page (wait for elements), and execute JavaScript to extract data. It runs in headless mode.
+*   **gspread**: To interact with the Google Sheets API. This library handles authentication and allows the script to read from and append data to a Google Spreadsheet.
+*   **google-auth**: For handling Google API authentication using service account credentials.
+
+**Core Logic:**
+1.  **Google Sheets Connection & Existing Data Retrieval**:
+    *   The script first establishes a connection to Google Sheets using service account credentials (provided via an environment variable).
+    *   It opens a specific worksheet named "その他" within the designated spreadsheet (URL also from an environment variable).
+    *   It reads all existing data from this sheet, specifically collecting all "Detail URLs" from the third column. These URLs are normalized using the `strip_query_params` helper function and stored in a set for efficient duplicate checking.
+2.  **Web Scraping with Playwright**:
+    *   The script launches a headless Chromium browser using Playwright.
+    *   It navigates to `https://moshoripa.com/` and waits for the page to become idle and for the gacha card elements (`div.homes-gacha-card`) to be present.
+    *   Data extraction is performed using `page.evaluate()`, which executes JavaScript code in the browser's context to select elements and retrieve their attributes (text, href, src). Selectors used are specific to the structure of moshoripa.com (e.g., `a.gacha-link`, `div.gacha-price span.font-size-xl`).
+    *   Relative URLs (for images and detail pages) extracted from the site are converted into absolute URLs by prepending `https://moshoripa.com`.
+3.  **Data Processing & Duplicate Filtering**:
+    *   A helper function, `strip_query_params(url: str) -> str`, is used to remove query parameters from URLs. This ensures that URLs differing only by query strings are treated as identical for duplicate checking purposes.
+    *   The script iterates through the scraped items. For each item, its `detail_url` is normalized and checked against the set of `existing_detail_urls` fetched from the Google Sheet.
+4.  **Appending New Data to Google Sheets**:
+    *   Only items whose normalized `detail_url` is not found in the `existing_detail_urls` set are considered new.
+    *   These new items (formatted as a list: `[Title, Image URL, Detail URL, PT]`) are collected.
+    *   If there are new items to add, they are appended as new rows to the "その他" worksheet using `sheet.append_rows()` with `value_input_option='USER_ENTERED'`.
+
+**Environment Variables Required for Execution:**
+*   `GSHEET_JSON`: A JSON string containing the Google Service Account credentials. This string might be base64 encoded, and the script attempts to decode it if necessary.
+*   `SPREADSHEET_URL`: The full URL of the Google Spreadsheet where data will be stored and read from.
+
+**Output:**
+The script's primary output is the addition of new data rows to the "その他" sheet in the Google Spreadsheet specified by `SPREADSHEET_URL`. Each row contains the [Title, Image URL, Detail URL, PT] for a newly scraped item. The script also prints logs to standard output indicating its progress, errors, and the number of items added or skipped.
+
+**Error Handling:**
+The script incorporates error handling for various potential issues:
+*   Missing or invalid environment variables (`GSHEET_JSON`, `SPREADSHEET_URL`).
+*   Errors during Google Sheets connection (e.g., spreadsheet not found, worksheet not found, authentication issues).
+*   Errors during Playwright operations (e.g., navigation timeouts, elements not found).
+*   If an error occurs during Playwright scraping, the script attempts to save the current page content to `moshoripa_debug.html` for debugging purposes.
+*   It also includes checks for malformed or missing data during the scraping and processing phases.
+
+**Execution Context:**
+This script is designed to be run in automated environments, such as GitHub Actions. It uses a headless browser, relies on environment variables for configuration, and includes logging suitable for such contexts. The inclusion of `--no-sandbox` for the Chromium launch arguments is also indicative of this.
+
+This prompt should provide a comprehensive overview for an AI to understand, modify, or explain the `moshoripa_scraper.py` script.

--- a/moshoripa_scraper.py
+++ b/moshoripa_scraper.py
@@ -1,0 +1,187 @@
+import os
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+from urllib.parse import urlparse
+import base64
+import json
+
+def strip_query_params(url: str) -> str:
+  """Removes query parameters from a URL."""
+  parsed = urlparse(url)
+  return parsed.scheme + "://" + parsed.netloc + parsed.path
+
+if __name__ == "__main__":
+  print("Connecting to Google Sheets...")
+  scopes = ["https://www.googleapis.com/auth/spreadsheets", "https://www.googleapis.com/auth/drive"]
+  
+  try:
+    gsheet_json_str = os.environ['GSHEET_JSON']
+  except KeyError:
+    print("Error: GSHEET_JSON environment variable not set.")
+    exit(1)
+
+  try:
+    # Try decoding if it's base64 encoded
+    credentials_dict = json.loads(base64.b64decode(gsheet_json_str))
+  except (TypeError, ValueError, json.JSONDecodeError):
+    # Assume it's plain JSON if decoding fails
+    try:
+      credentials_dict = json.loads(gsheet_json_str)
+    except json.JSONDecodeError as e:
+      print(f"Error: Could not parse GSHEET_JSON: {e}")
+      exit(1)
+
+  try:
+    creds = Credentials.from_service_account_info(credentials_dict, scopes=scopes)
+    gc = gspread.authorize(creds)
+
+    spreadsheet_url = os.environ.get("SPREADSHEET_URL")
+    if not spreadsheet_url:
+      print("Error: SPREADSHEET_URL environment variable not set.")
+      exit(1)
+    
+    spreadsheet = gc.open_by_url(spreadsheet_url)
+    sheet = spreadsheet.worksheet("その他")
+    print("Successfully connected to worksheet 'その他'")
+
+    # Fetch existing detail URLs
+    print("Fetching existing detail URLs from the sheet...")
+    existing_detail_urls = set()
+    try:
+      all_rows = sheet.get_all_values()
+      if not all_rows:
+        print("The 'その他' sheet is empty.")
+      else:
+        for row_index, row in enumerate(all_rows[1:]): # Skip header row
+          if len(row) > 2 and row[2]: # Check if URL column exists and is not empty
+            url = row[2]
+            normalized_url = strip_query_params(url)
+            existing_detail_urls.add(normalized_url)
+          elif len(row) <=2 and row_index > 0 : # only print warning if it's not the header and not empty
+             print(f"Warning: Row {row_index + 2} has less than 3 columns or the URL is empty. Skipping.")
+        print(f"Found {len(existing_detail_urls)} existing detail URLs in the sheet.")
+    except Exception as e:
+      print(f"An error occurred while fetching existing URLs: {e}")
+      # Decide if you want to exit or continue. For now, let's continue.
+      # exit(1) 
+
+  except gspread.exceptions.SpreadsheetNotFound:
+    print(f"Error: Spreadsheet not found at URL: {spreadsheet_url}")
+    exit(1)
+  except gspread.exceptions.WorksheetNotFound:
+    print(f"Error: Worksheet 'その他' not found in the spreadsheet.")
+    exit(1)
+  except Exception as e:
+    print(f"An unexpected error occurred during Google Sheets connection: {e}")
+    exit(1)
+
+  print("Starting Playwright scraping logic...")
+  scraped_data = []
+  
+  try:
+    with sync_playwright() as p:
+      browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+      page = browser.new_page()
+      
+      print("Navigating to https://moshoripa.com/ ...")
+      page.goto("https://moshoripa.com/", timeout=60000, wait_until="networkidle")
+      print("Page navigation successful.")
+      
+      print("Waiting for gacha cards to load...")
+      page.wait_for_selector("div.homes-gacha-card", timeout=60000)
+      print("Gacha cards loaded.")
+      
+      print("Extracting data from page...")
+      items = page.evaluate('''() => {
+        const cards = Array.from(document.querySelectorAll('div.homes-gacha-card'));
+        return cards.map(card => {
+          const detail_url_element = card.querySelector('a.gacha-link');
+          const detail_url = detail_url_element ? detail_url_element.href : null;
+          
+          const image_element = card.querySelector('a.gacha-link > img');
+          const image_url = image_element ? image_element.src : null;
+          
+          let title = detail_url_element ? detail_url_element.textContent.trim() : '';
+          if (!title || title.length < 2) { // Check if title is empty or mostly whitespace
+            title = image_element ? image_element.alt.trim() : 'No title';
+          }
+          if (!title) title = 'No title';
+
+
+          const pt_element = card.querySelector('div.gacha-price span.font-size-xl');
+          const pt = pt_element ? pt_element.textContent.trim() : '0';
+          
+          return { title, image_url, detail_url, pt };
+        });
+      }''')
+      
+      print(f"Found {len(items)} items on the page.")
+      
+      for item in items:
+        if item['image_url'] and item['image_url'].startswith('/'):
+          item['image_url'] = f"https://moshoripa.com{item['image_url']}"
+        if item['detail_url'] and item['detail_url'].startswith('/'):
+          item['detail_url'] = f"https://moshoripa.com{item['detail_url']}"
+        
+        scraped_data.append([
+          item['title'], 
+          item['image_url'], 
+          item['detail_url'], 
+          item['pt']
+        ])
+        
+      browser.close()
+      print("Browser closed.")
+      
+  except Exception as e:
+    print(f"An error occurred during Playwright scraping: {e}")
+    if 'page' in locals() and page:
+      try:
+        page_content = page.content()
+        with open("moshoripa_debug.html", "w", encoding="utf-8") as f:
+          f.write(page_content)
+        print("Page content saved to moshoripa_debug.html")
+      except Exception as save_e:
+        print(f"Could not save page content: {save_e}")
+    if 'browser' in locals() and browser:
+      browser.close()
+      print("Browser closed due to error.")
+    # Decide if you want to exit or continue. For now, let's add to scraped_data and continue
+    # exit(1)
+
+  print("Processing scraped data and appending to Google Sheets...")
+  new_rows_to_append = []
+
+  if not scraped_data:
+    print("No data was scraped. Skipping processing and appending.")
+  else:
+    for item_index, item in enumerate(scraped_data):
+      if not item or len(item) < 3:
+        print(f"Warning: Scraped item at index {item_index} is malformed or None. Skipping. Data: {item}")
+        continue
+
+      detail_url = item[2]
+      if not detail_url:
+        print(f"Warning: Scraped item '{item[0]}' (index {item_index}) has no detail_url. Skipping.")
+        continue
+      
+      normalized_url = strip_query_params(detail_url)
+      
+      if normalized_url not in existing_detail_urls:
+        new_rows_to_append.append(item)
+        print(f"✅ Adding new item: {item[0]}")
+      else:
+        print(f"⏭ Skipping duplicate: {item[0]} - {detail_url}")
+        
+    if new_rows_to_append:
+      print(f"Attempting to append {len(new_rows_to_append)} new items to the sheet...")
+      try:
+        sheet.append_rows(new_rows_to_append, value_input_option='USER_ENTERED')
+        print(f"📥 Appended {len(new_rows_to_append)} new items to the sheet.")
+      except Exception as e:
+        print(f"An error occurred while appending rows to Google Sheets: {e}")
+    else:
+      print("📭 No new data to append.")
+  
+  print("Script finished.")


### PR DESCRIPTION
This script scrapes gacha information (title, image URL, detail URL, and points) from https://moshoripa.com/.

Key features:
- Uses Playwright for web scraping.
- Integrates with Google Sheets using gspread API for data storage.
- Fetches existing detail URLs from the 'その他' sheet to prevent duplicates.
- Appends only new gacha data to the spreadsheet.
- Configured via environment variables (GSHEET_JSON, SPREADSHEET_URL) for secure credential management and flexible sheet targeting.
- Includes error handling for network, scraping, and sheet operations.
- Saves debug HTML on scraping errors.
- Designed for headless execution, suitable for GitHub Actions.
- An AI assistant prompt is available in ai_prompt.txt.