### PR TITLE
Add ichica scraper

### DIFF
--- a/.github/workflows/scrape_ichica.yml
+++ b/.github/workflows/scrape_ichica.yml
@@ -1,0 +1,40 @@
+name: Scrape Ichica
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *'
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install Playwright browsers
+        run: |
+          python -m playwright install --with-deps
+
+      - name: Run scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+          SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
+        run: python ichica_scraper.py
+
+      - name: Upload debug HTML
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ichica_debug
+          path: ichica_debug.html

--- a/README.md
+++ b/README.md
@@ -161,3 +161,18 @@ python oripa_toreca_rainbow_scraper.py
 ```
 
 The workflow `.github/workflows/scrape_toreca_rainbow.yml` runs this scraper automatically.
+
+## Ichica Scraper
+
+The `ichica_scraper.py` script collects gacha information from [ichica.co](https://ichica.co/). It uses Playwright to gather the title, image URL, detail page URL and PT value from the main page. New rows are appended to the `その他` sheet, skipping entries with a duplicate URL.
+
+Run locally:
+
+```bash
+pip install -r requirements.txt
+export GSHEET_JSON=<BASE64_SERVICE_ACCOUNT_JSON>
+export SPREADSHEET_URL=<YOUR_SHEET_URL>
+python ichica_scraper.py
+```
+
+The workflow `.github/workflows/scrape_ichica.yml` runs this scraper automatically.

--- a/ichica_scraper.py
+++ b/ichica_scraper.py
@@ -1,0 +1,139 @@
+import os
+import base64
+from typing import List
+from urllib.parse import urljoin, urlparse
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "https://ichica.co/"
+SHEET_NAME = "その他"
+SPREADSHEET_URL = os.environ.get("SPREADSHEET_URL")
+
+
+def save_credentials() -> str:
+    encoded = os.environ.get("GSHEET_JSON", "")
+    if not encoded:
+        raise RuntimeError("GSHEET_JSON environment variable is missing")
+    with open("credentials.json", "w") as f:
+        f.write(base64.b64decode(encoded).decode("utf-8"))
+    return "credentials.json"
+
+
+def get_sheet():
+    creds_path = save_credentials()
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    client = gspread.authorize(creds)
+    if not SPREADSHEET_URL:
+        raise RuntimeError("SPREADSHEET_URL environment variable is missing")
+    spreadsheet = client.open_by_url(SPREADSHEET_URL)
+    return spreadsheet.worksheet(SHEET_NAME)
+
+
+def fetch_existing_urls(sheet) -> set:
+    """Return set of detail URLs already in the sheet (3rd column)."""
+    records = sheet.get_all_values()
+    url_set = set()
+    for row in records[1:]:
+        if len(row) >= 3:
+            url_set.add(row[2].strip())
+    return url_set
+
+
+def normalize_url(url: str) -> str:
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+
+
+def scrape_items(existing_urls: set) -> List[List[str]]:
+    rows: List[List[str]] = []
+    html = ""
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        page = browser.new_page(user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
+        print("🔍 ichica.co スクレイピング開始...")
+        try:
+            page.goto(BASE_URL, timeout=120000, wait_until="domcontentloaded")
+            page.wait_for_selector("div.bubble-element.group-item", timeout=120000)
+        except Exception as exc:
+            print(f"🛑 ページ読み込み失敗: {exc}")
+            html = page.content()
+            browser.close()
+            if html:
+                with open("ichica_debug.html", "w", encoding="utf-8") as f:
+                    f.write(html)
+            return rows
+
+        items = page.evaluate(
+            """
+            () => {
+                const results = [];
+                document.querySelectorAll('div.bubble-element.group-item').forEach(card => {
+                    const img = card.querySelector('img');
+                    const image = img ? img.src : '';
+                    const title = img ? (img.alt || img.title || '').trim() : '';
+                    let url = '';
+                    const a = card.querySelector('a[href]');
+                    if (a) {
+                        url = a.href;
+                    } else {
+                        const onclick = card.getAttribute('onclick');
+                        const m = onclick && onclick.match(/window.open\('([^']+)'/);
+                        if (m) url = m[1];
+                    }
+                    const ptEl = card.querySelector('div.cmgaAy');
+                    const pt = ptEl ? ptEl.textContent.trim() : '';
+                    results.push({ title, image, url, pt });
+                });
+                return results;
+            }
+            """
+        )
+        html = page.content()
+        browser.close()
+
+    for item in items:
+        detail_url = item.get("url", "").strip()
+        image_url = item.get("image", "").strip()
+        title = item.get("title", "noname") or "noname"
+        pt_value = item.get("pt", "").strip()
+
+        if detail_url.startswith("/"):
+            detail_url = urljoin(BASE_URL, detail_url)
+        if image_url.startswith("/"):
+            image_url = urljoin(BASE_URL, image_url)
+
+        norm_url = normalize_url(detail_url)
+        if norm_url in existing_urls or not norm_url:
+            continue
+
+        rows.append([title, image_url, detail_url, pt_value])
+        existing_urls.add(norm_url)
+
+    if html:
+        with open("ichica_debug.html", "w", encoding="utf-8") as f:
+            f.write(html)
+    return rows
+
+
+def main() -> None:
+    sheet = get_sheet()
+    existing_urls = fetch_existing_urls(sheet)
+    rows = scrape_items(existing_urls)
+    if not rows:
+        print("📭 新規データなし")
+        return
+    try:
+        sheet.append_rows(rows, value_input_option="USER_ENTERED")
+        print(f"📥 {len(rows)} 件追記完了")
+    except Exception as exc:
+        print(f"❌ スプレッドシート書き込み失敗: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add ichica_scraper.py using Playwright
- add workflow to run scraper on schedule
- document ichica scraper usage
- improve ichica scraper reliability with user agent and debug output

## Testing
- `python -m py_compile ichica_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_6843be68a2208323a286ad8e69d7b2e1