### PR TITLE
Add Dopa Game banner scraper

### DIFF
--- a/.github/workflows/scrape_dopa_banner.yml
+++ b/.github/workflows/scrape_dopa_banner.yml
@@ -1,0 +1,33 @@
+name: Scrape Dopa Game Banners
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install Playwright browsers
+        run: |
+          python -m playwright install --with-deps
+
+      - name: Run banner scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+          SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
+        run: python dopa_game_banner_scraper.py

--- a/README.md
+++ b/README.md
@@ -130,6 +130,21 @@ python dopa_game_scraper.py
 
 The workflow `.github/workflows/scrape_dopa_game.yml` runs this scraper automatically.
 
+## Dopa Game Banner Scraper
+
+The `dopa_game_banner_scraper.py` script retrieves banner image URLs from [dopa-game.jp](https://dopa-game.jp/). It uses Playwright to collect the alt text, image URL and site URL from the top page slider and appends them to the `news` sheet, skipping entries with a duplicate image URL.
+
+Run locally:
+
+```bash
+pip install -r requirements.txt
+export GSHEET_JSON=<BASE64_SERVICE_ACCOUNT_JSON>
+export SPREADSHEET_URL=<YOUR_SHEET_URL>
+python dopa_game_banner_scraper.py
+```
+
+The workflow `.github/workflows/scrape_dopa_banner.yml` runs this scraper automatically.
+
 
 ## Ram Oripa Scraper
 

--- a/dopa_game_banner_scraper.py
+++ b/dopa_game_banner_scraper.py
@@ -1,0 +1,94 @@
+import os
+import base64
+from typing import List
+from urllib.parse import urljoin
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "https://dopa-game.jp/"
+SHEET_NAME = "news"
+SPREADSHEET_URL = os.environ.get("SPREADSHEET_URL")
+
+BANNER_IMG_SELECTOR = "div.slick-slider img"
+
+
+def save_credentials() -> str:
+    encoded = os.environ.get("GSHEET_JSON", "")
+    if not encoded:
+        raise RuntimeError("GSHEET_JSON environment variable is missing")
+    with open("credentials.json", "w") as f:
+        f.write(base64.b64decode(encoded).decode("utf-8"))
+    return "credentials.json"
+
+
+def get_sheet():
+    creds_path = save_credentials()
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    client = gspread.authorize(creds)
+    if not SPREADSHEET_URL:
+        raise RuntimeError("SPREADSHEET_URL environment variable is missing")
+    spreadsheet = client.open_by_url(SPREADSHEET_URL)
+    return spreadsheet.worksheet(SHEET_NAME)
+
+
+def fetch_existing_image_urls(sheet) -> set:
+    records = sheet.get_all_values()
+    urls = set()
+    for row in records[1:]:
+        if len(row) >= 2:
+            urls.add(row[1].strip())
+    return urls
+
+
+def scrape_banners(existing_urls: set) -> List[List[str]]:
+    rows: List[List[str]] = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        page = browser.new_page()
+        print("🔍 dopa-game.jp banner scraping...")
+        try:
+            page.goto(BASE_URL, timeout=60000, wait_until="networkidle")
+            page.wait_for_selector(BANNER_IMG_SELECTOR, timeout=60000)
+        except Exception as exc:
+            print(f"🛑 page load failed: {exc}")
+            browser.close()
+            return rows
+        imgs = page.query_selector_all(BANNER_IMG_SELECTOR)
+        print(f"found {len(imgs)} banner images")
+        for img in imgs:
+            src = (img.get_attribute("src") or "").strip()
+            if not src:
+                continue
+            if src.startswith("/"):
+                src = urljoin(BASE_URL, src)
+            if src in existing_urls:
+                continue
+            alt = (img.get_attribute("alt") or "noname").strip() or "noname"
+            rows.append([alt, src, BASE_URL, ""])
+            existing_urls.add(src)
+        browser.close()
+    return rows
+
+
+def main() -> None:
+    sheet = get_sheet()
+    existing = fetch_existing_image_urls(sheet)
+    rows = scrape_banners(existing)
+    if not rows:
+        print("📭 No new banners")
+        return
+    try:
+        sheet.append_rows(rows, value_input_option="USER_ENTERED")
+        print(f"📥 {len(rows)} rows appended")
+    except Exception as exc:
+        print(f"❌ Failed to write to sheet: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scrape banner images from dopa-game.jp with Playwright
- append results to `news` sheet
- run new scraper via workflow
- document Dopa Game banner scraper in README

## Testing
- `python -m py_compile dopa_game_banner_scraper.py`
- `python dopa_game_banner_scraper.py` *(fails: ModuleNotFoundError: No module named 'gspread')*

------
https://chatgpt.com/codex/tasks/task_e_686be445cac48323a4a3e4eeabb0dc0e