### PR TITLE
Add Tora Net Oripa scraper

### DIFF
--- a/.github/workflows/scrape_tora_net_oripa.yml
+++ b/.github/workflows/scrape_tora_net_oripa.yml
@@ -1,0 +1,40 @@
+name: Scrape Tora Net Oripa
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */3 * * *'
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install Playwright browsers
+        run: |
+          python -m playwright install --with-deps
+
+      - name: Run scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+          SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
+        run: python tora_net_oripa_scraper.py
+
+      - name: Upload debug HTML
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tora_net_oripa_debug
+          path: tora_net_oripa_debug.html

--- a/README.md
+++ b/README.md
@@ -340,3 +340,18 @@ python jinstudiooripa_scraper.py
 ```
 
 The workflow `.github/workflows/scrape_jinstudiooripa.yml` runs this scraper automatically.
+
+## Tora Net Oripa Scraper
+
+The `tora_net_oripa_scraper.py` script collects gacha information from [tora.net-oripa.com](https://tora.net-oripa.com/). It uses Playwright to scrape the top page and gathers the title, image URL, detail page URL and PT value from each entry. New rows are appended to the `その他` sheet while skipping entries with duplicate URLs.
+
+Run locally:
+
+```bash
+pip install -r requirements.txt
+export GSHEET_JSON=<BASE64_SERVICE_ACCOUNT_JSON>
+export SPREADSHEET_URL=<YOUR_SHEET_URL>
+python tora_net_oripa_scraper.py
+```
+
+The workflow `.github/workflows/scrape_tora_net_oripa.yml` runs this scraper automatically.

--- a/tora_net_oripa_scraper.py
+++ b/tora_net_oripa_scraper.py
@@ -1,0 +1,129 @@
+import os
+import base64
+from typing import List
+from urllib.parse import urljoin
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "https://tora.net-oripa.com/"
+SHEET_NAME = "その他"
+SPREADSHEET_URL = os.environ.get("SPREADSHEET_URL")
+
+def save_credentials() -> str:
+    encoded = os.environ.get("GSHEET_JSON", "")
+    if not encoded:
+        raise RuntimeError("GSHEET_JSON environment variable is missing")
+    with open("credentials.json", "w") as f:
+        f.write(base64.b64decode(encoded).decode("utf-8"))
+    return "credentials.json"
+
+def get_sheet():
+    creds_path = save_credentials()
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    client = gspread.authorize(creds)
+    if not SPREADSHEET_URL:
+        raise RuntimeError("SPREADSHEET_URL environment variable is missing")
+    spreadsheet = client.open_by_url(SPREADSHEET_URL)
+    return spreadsheet.worksheet(SHEET_NAME)
+
+def fetch_existing_urls(sheet) -> set:
+    records = sheet.get_all_values()
+    urls = set()
+    for row in records[1:]:
+        if len(row) >= 3:
+            urls.add(row[2].strip())
+    return urls
+
+def parse_items(page) -> List[dict]:
+    return page.evaluate("""
+        () => {
+            const results = [];
+            document.querySelectorAll('section.overflow-hidden').forEach(sec => {
+                const a = sec.querySelector('a[href]');
+                if (!a) return;
+                let url = a.getAttribute('href') || '';
+                let image = '';
+                const img = sec.querySelector('img');
+                if (img) {
+                    const srcset = img.getAttribute('srcset');
+                    if (srcset) {
+                        const parts = srcset.split(',').map(p => p.trim().split(' ')[0]);
+                        if (parts.length) image = parts[parts.length - 1];
+                    } else {
+                        image = img.getAttribute('src') || '';
+                    }
+                }
+                let title = '';
+                const titleEl = sec.querySelector('h2, h3, p.font-bold, span.font-bold');
+                if (titleEl) {
+                    title = titleEl.textContent.trim();
+                } else if (img) {
+                    title = img.getAttribute('alt') || '';
+                }
+                const ptEl = sec.querySelector('span.text-xl.font-bold, span.font-semibold');
+                const pt = ptEl ? ptEl.textContent.replace(/[^0-9]/g, '') : '';
+                results.push({title, image, url, pt});
+            });
+            return results;
+        }
+    """)
+
+def scrape_items(existing_urls: set) -> List[List[str]]:
+    rows: List[List[str]] = []
+    debug_html = ""
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        page = browser.new_page()
+        print('🔍 tora.net-oripa.com スクレイピング開始...')
+        try:
+            page.goto(BASE_URL, timeout=60000, wait_until='networkidle')
+            page.wait_for_selector('section.overflow-hidden', timeout=60000)
+        except Exception as exc:
+            print(f'🛑 ページ読み込み失敗: {exc}')
+            debug_html = page.content()
+            browser.close()
+            with open('tora_net_oripa_debug.html', 'w', encoding='utf-8') as f:
+                f.write(debug_html)
+            return rows
+        items = parse_items(page)
+        debug_html = page.content()
+        browser.close()
+    for item in items:
+        detail_url = item.get('url', '').strip()
+        image_url = item.get('image', '').strip()
+        title = item.get('title', 'noname').strip() or 'noname'
+        pt_text = item.get('pt', '').strip()
+        if detail_url.startswith('/'):
+            detail_url = urljoin(BASE_URL, detail_url)
+        if image_url.startswith('/'):
+            image_url = urljoin(BASE_URL, image_url)
+        if detail_url in existing_urls:
+            print(f'⏭ スキップ（重複）: {title}')
+            continue
+        rows.append([title, image_url, detail_url, pt_text])
+        existing_urls.add(detail_url)
+    with open('tora_net_oripa_debug.html', 'w', encoding='utf-8') as f:
+        f.write(debug_html)
+    return rows
+
+def main() -> None:
+    sheet = get_sheet()
+    existing_urls = fetch_existing_urls(sheet)
+    rows = scrape_items(existing_urls)
+    if not rows:
+        print('📭 新規データなし')
+        return
+    try:
+        sheet.append_rows(rows, value_input_option='USER_ENTERED')
+        print(f'📥 {len(rows)} 件追記完了')
+    except Exception as exc:
+        print(f'❌ スプレッドシート書き込み失敗: {exc}')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add scraper for tora.net-oripa.com and workflow
- document running the new scraper in README

## Testing
- `python -m py_compile tora_net_oripa_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_6870fedf127c8323b65dfe5884c7cb93