### PR TITLE
Add Oripa Dash banner scraper

### DIFF
--- a/.github/workflows/scrape_oripa_dash_banner.yml
+++ b/.github/workflows/scrape_oripa_dash_banner.yml
@@ -1,0 +1,30 @@
+name: Scrape Oripa Dash Banner
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m playwright install --with-deps
+
+      - name: Run banner scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+          SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
+        run: python oripa_dash_banner_scraper.py

--- a/README.md
+++ b/README.md
@@ -146,6 +146,21 @@ python dopa_game_banner_scraper.py
 The workflow `.github/workflows/scrape_dopa_banner.yml` runs this scraper automatically.
 
 
+## Oripa Dash Banner Scraper
+
+The `oripa_dash_banner_scraper.py` script retrieves banner image URLs from [oripa-dash.com](https://oripa-dash.com/user/packList). It uses Playwright to collect the image URL and site URL from the top slider and appends them to the `news` sheet, skipping entries with a duplicate image URL.
+
+Run locally:
+
+```bash
+pip install -r requirements.txt
+export GSHEET_JSON=<BASE64_SERVICE_ACCOUNT_JSON>
+export SPREADSHEET_URL=<YOUR_SHEET_URL>
+python oripa_dash_banner_scraper.py
+```
+
+The workflow `.github/workflows/scrape_oripa_dash_banner.yml` runs this scraper automatically.
+
 ## Ram Oripa Scraper
 
 The `ram_oripa_scraper.py` script gathers gacha information from [ram-oripa.com](https://ram-oripa.com/). It uses Playwright to scrape the top page and collects the title, image URL, detail page URL and PT value. New entries are appended to the `その他` sheet, skipping duplicates.

--- a/oripa_dash_banner_scraper.py
+++ b/oripa_dash_banner_scraper.py
@@ -1,0 +1,91 @@
+import os
+import base64
+from urllib.parse import urljoin
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "https://oripa-dash.com/user/packList"
+SHEET_NAME = "news"
+SPREADSHEET_URL = os.environ.get("SPREADSHEET_URL")
+
+
+def save_credentials() -> str:
+    encoded = os.environ.get("GSHEET_JSON", "")
+    if not encoded:
+        raise RuntimeError("GSHEET_JSON environment variable is missing")
+    with open("credentials.json", "w") as f:
+        f.write(base64.b64decode(encoded).decode("utf-8"))
+    return "credentials.json"
+
+
+def get_sheet():
+    creds_path = save_credentials()
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    client = gspread.authorize(creds)
+    if not SPREADSHEET_URL:
+        raise RuntimeError("SPREADSHEET_URL environment variable is missing")
+    spreadsheet = client.open_by_url(SPREADSHEET_URL)
+    return spreadsheet.worksheet(SHEET_NAME)
+
+
+def fetch_existing_image_urls(sheet) -> set:
+    records = sheet.get_all_values()
+    urls = set()
+    for row in records[1:]:
+        if len(row) >= 1:
+            urls.add(row[0].strip())
+    return urls
+
+
+def scrape_banners(existing_urls: set):
+    rows = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        page = browser.new_page()
+        print("🔍 oripa-dash.com スクレイピング開始...")
+        try:
+            page.goto(BASE_URL, timeout=60000, wait_until="networkidle")
+            page.wait_for_selector(".swiper-slide img", timeout=60000)
+        except Exception as exc:
+            print(f"🛑 ページ読み込み失敗: {exc}")
+            html = page.content()
+            with open("oripa_dash_banner_debug.html", "w", encoding="utf-8") as f:
+                f.write(html)
+            browser.close()
+            return rows
+
+        images = page.query_selector_all(".swiper-slide img")
+        for img in images:
+            src = img.get_attribute("src") or ""
+            src = src.strip()
+            if not src:
+                continue
+            if src.startswith("/"):
+                src = urljoin(BASE_URL, src)
+            if src not in existing_urls:
+                rows.append([src, BASE_URL])
+                existing_urls.add(src)
+        browser.close()
+    print(f"✅ {len(rows)} 件の新規バナー")
+    return rows
+
+
+def main() -> None:
+    sheet = get_sheet()
+    existing = fetch_existing_image_urls(sheet)
+    rows = scrape_banners(existing)
+    if not rows:
+        print("📭 新規データなし")
+        return
+    sheet.append_rows(rows, value_input_option="USER_ENTERED")
+    print(f"📥 {len(rows)} 件追記完了")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Playwright scraper `oripa_dash_banner_scraper.py` to collect slider image URLs from oripa-dash.com and append them to the `news` sheet
- document usage in README
- add GitHub Actions workflow `scrape_oripa_dash_banner.yml` to run the scraper on schedule

## Testing
- `python -m py_compile oripa_dash_banner_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_6871230dba508323a42b2e4a7d6dff4f