### PR TITLE
Add Dopa Game banner scraper

### DIFF
--- a/.github/workflows/scrape_dopa_banner.yml
+++ b/.github/workflows/scrape_dopa_banner.yml
@@ -1,0 +1,30 @@
+name: Scrape Dopa Banner
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m playwright install --with-deps
+
+      - name: Run banner scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+          SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
+        run: python dopa_game_banner_scraper.py

--- a/dopa_game_banner_scraper.py
+++ b/dopa_game_banner_scraper.py
@@ -1,0 +1,98 @@
+import base64
+import os
+from urllib.parse import urljoin
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "https://dopa-game.jp"
+TARGET_URL = BASE_URL
+SHEET_NAME = "news"
+SPREADSHEET_URL = os.environ.get("SPREADSHEET_URL")
+
+
+def save_credentials() -> str:
+    encoded = os.environ.get("GSHEET_JSON", "")
+    if not encoded:
+        raise RuntimeError("GSHEET_JSON environment variable is missing")
+    with open("credentials.json", "w") as f:
+        f.write(base64.b64decode(encoded).decode("utf-8"))
+    return "credentials.json"
+
+
+def get_sheet():
+    creds_path = save_credentials()
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    client = gspread.authorize(creds)
+    if not SPREADSHEET_URL:
+        raise RuntimeError("SPREADSHEET_URL environment variable is missing")
+    spreadsheet = client.open_by_url(SPREADSHEET_URL)
+    return spreadsheet.worksheet(SHEET_NAME)
+
+
+def fetch_existing_image_urls(sheet) -> set:
+    records = sheet.get_all_values()
+    return set(row[0].strip() for row in records[1:] if row and row[0].strip())
+
+
+def scrape_banners(existing_urls: set):
+    print("🔍 Playwright によるスクレイピング開始...")
+    rows = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        page = browser.new_page(
+            user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
+        )
+        try:
+            page.goto(TARGET_URL, timeout=60000, wait_until="load")
+            page.wait_for_timeout(8000)
+            slides = page.query_selector_all(".slick-slide")
+        except Exception as e:
+            print(f"🛑 読み込み失敗: {e}")
+            browser.close()
+            return rows
+
+        for slide in slides:
+            img = slide.query_selector("img")
+            link = slide.query_selector("a")
+
+            if not img:
+                continue
+
+            src = img.get_attribute("src") or ""
+            href = link.get_attribute("href") if link else ""
+
+            if not src:
+                continue
+
+            src = urljoin(BASE_URL, src)
+            href = urljoin(BASE_URL, href) if href else TARGET_URL
+
+            if src not in existing_urls:
+                rows.append([src, href])
+                existing_urls.add(src)
+
+        browser.close()
+
+    print(f"✅ {len(rows)} 件の新規バナー")
+    return rows
+
+
+def main() -> None:
+    sheet = get_sheet()
+    existing = fetch_existing_image_urls(sheet)
+    rows = scrape_banners(existing)
+    if not rows:
+        print("📭 新規データなし")
+        return
+    sheet.append_rows(rows, value_input_option="USER_ENTERED")
+    print(f"📥 {len(rows)} 件追記完了")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a scraper for Dopa Game banners
- automate it with `scrape_dopa_banner` workflow
- simplify banner script to store just image and link

## Testing
- `python -m py_compile dopa_game_banner_scraper.py`
- `pip install -q gspread google-auth playwright` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6872311464588323ba5b216c12fa566b