### PR TITLE
Add Kagura TCG scraper

### DIFF
--- a/.github/workflows/scrape_kagura.yml
+++ b/.github/workflows/scrape_kagura.yml
@@ -1,0 +1,37 @@
+name: Scrape Kagura TCG
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */3 * * *'
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m playwright install --with-deps
+
+      - name: Run scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+          SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
+        run: python kagura_tcg_scraper.py
+
+      - name: Upload debug HTML
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kagura_debug
+          path: kagura_debug.html

--- a/README.md
+++ b/README.md
@@ -509,3 +509,18 @@ python pokepa365_scraper.py
 ```
 
 The workflow `.github/workflows/scrape_pokepa365.yml` runs this scraper automatically.
+
+## Kagura TCG Scraper
+
+The `kagura_tcg_scraper.py` script collects gacha information from [kagura-tcg.com](https://kagura-tcg.com/). It uses Playwright to scrape the top page and gathers the title, image URL, detail page URL and PT value from each entry. New rows are appended to the `その他` sheet while skipping entries with duplicate URLs.
+
+Run locally:
+
+```bash
+pip install -r requirements.txt
+export GSHEET_JSON=<BASE64_SERVICE_ACCOUNT_JSON>
+export SPREADSHEET_URL=<YOUR_SHEET_URL>
+python kagura_tcg_scraper.py
+```
+
+The workflow `.github/workflows/scrape_kagura.yml` runs this scraper automatically.

--- a/kagura_tcg_scraper.py
+++ b/kagura_tcg_scraper.py
@@ -1,0 +1,140 @@
+import os
+import base64
+import re
+from urllib.parse import urljoin, urlparse
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "https://kagura-tcg.com/"
+SHEET_NAME = "その他"
+SPREADSHEET_URL = os.environ.get("SPREADSHEET_URL")
+
+
+def save_credentials() -> str:
+    encoded = os.environ.get("GSHEET_JSON", "")
+    if not encoded:
+        raise RuntimeError("GSHEET_JSON environment variable is missing")
+    with open("credentials.json", "w") as f:
+        f.write(base64.b64decode(encoded).decode("utf-8"))
+    return "credentials.json"
+
+
+def get_sheet():
+    creds_path = save_credentials()
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    client = gspread.authorize(creds)
+    if not SPREADSHEET_URL:
+        raise RuntimeError("SPREADSHEET_URL environment variable is missing")
+    spreadsheet = client.open_by_url(SPREADSHEET_URL)
+    return spreadsheet.worksheet(SHEET_NAME)
+
+
+def strip_query(url: str) -> str:
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+
+
+def fetch_existing_urls(sheet) -> set:
+    records = sheet.get_all_values()
+    urls = set()
+    for row in records[1:]:
+        if len(row) >= 3:
+            u = row[2].strip()
+            if u:
+                urls.add(strip_query(u))
+    return urls
+
+
+def parse_items(page):
+    return page.evaluate(
+        """
+        () => {
+            const results = [];
+            document.querySelectorAll('div.flex.flex-col.cursor-pointer').forEach(box => {
+                let url = '';
+                const link = box.closest('a[href]') || box.querySelector('a[href]');
+                if (link) url = link.href;
+                let image = '';
+                const imgDiv = box.querySelector('div[style*="background-image"]');
+                if (imgDiv) {
+                    const m = imgDiv.style.backgroundImage.match(/url\([\"']?(.*?)[\"']?\)/);
+                    if (m) image = m[1];
+                }
+                let title = '';
+                const titleEl = box.querySelector('div.font-bold') || box.querySelector('h3');
+                if (titleEl) title = titleEl.textContent.trim();
+                let pt = '';
+                const ptEl = box.querySelector('div.text-stone-100');
+                if (ptEl) pt = ptEl.textContent.replace(/\s+/g, '');
+                results.push({ title, image, url, pt });
+            });
+            return results;
+        }
+        """,
+    )
+
+
+def scrape_items(existing_urls: set) -> list:
+    rows = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        page = browser.new_page()
+        print("🔍 kagura-tcg.com スクレイピング開始...")
+        try:
+            page.goto(BASE_URL, timeout=60000, wait_until="networkidle")
+            page.wait_for_selector('div.flex.flex-col.cursor-pointer', timeout=60000)
+        except Exception as exc:
+            print(f"🛑 ページ読み込み失敗: {exc}")
+            html = page.content()
+            with open("kagura_debug.html", "w", encoding="utf-8") as f:
+                f.write(html)
+            browser.close()
+            return rows
+
+        items = parse_items(page)
+        browser.close()
+
+    for item in items:
+        detail_url = item.get("url", "").strip()
+        image_url = item.get("image", "").strip()
+        title = item.get("title", "noname").strip() or "noname"
+        pt_text = item.get("pt", "")
+        pt_value = re.sub(r"[^0-9]", "", pt_text)
+
+        if detail_url.startswith("/"):
+            detail_url = urljoin(BASE_URL, detail_url)
+        if image_url.startswith("/"):
+            image_url = urljoin(BASE_URL, image_url)
+
+        norm_url = strip_query(detail_url)
+        if norm_url in existing_urls:
+            print(f"⏭ スキップ（重複）: {title}")
+            continue
+
+        rows.append([title, image_url, detail_url, pt_value])
+        existing_urls.add(norm_url)
+    return rows
+
+
+def main() -> None:
+    sheet = get_sheet()
+    existing_urls = fetch_existing_urls(sheet)
+    rows = scrape_items(existing_urls)
+    if rows:
+        try:
+            sheet.append_rows(rows, value_input_option="USER_ENTERED")
+            print(f"📥 {len(rows)} 件追記完了")
+        except Exception as exc:
+            print(f"❌ スプレッドシート書き込み失敗: {exc}")
+    else:
+        print("📭 新規データなし")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Playwright scraper for kagura-tcg.com
- schedule scraper with a new GitHub Actions workflow
- document Kagura TCG scraper in README

## Testing
- `python -m py_compile kagura_tcg_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_6873cd56a08c83238924628738e69faf