### PR TITLE
Add Quest Oripa scraper

### DIFF
--- a/.github/workflows/scrape_quest_oripa.yml
+++ b/.github/workflows/scrape_quest_oripa.yml
@@ -1,0 +1,37 @@
+name: Scrape Quest Oripa
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */3 * * *'
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m playwright install --with-deps
+
+      - name: Run scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+          SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
+        run: python quest_oripa_scraper.py
+
+      - name: Upload debug HTML
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quest_oripa_debug
+          path: quest_oripa_debug.html

--- a/README.md
+++ b/README.md
@@ -525,3 +525,19 @@ python kagura_tcg_scraper.py
 ```
 
 The workflow `.github/workflows/scrape_kagura.yml` runs this scraper automatically.
+
+## Quest Oripa Scraper
+
+The `quest_oripa_scraper.py` script gathers gacha information from [quest-oripa.com](https://quest-oripa.com/). It uses Playwright to scrape the top page and collects the title, image URL, detail page URL and PT value from each entry. New rows are appended to the `その他` sheet while skipping entries with duplicate URLs.
+
+Run locally:
+
+```bash
+pip install -r requirements.txt
+playwright install
+export GSHEET_JSON=<BASE64_SERVICE_ACCOUNT_JSON>
+export SPREADSHEET_URL=<YOUR_SHEET_URL>
+python quest_oripa_scraper.py
+```
+
+The workflow `.github/workflows/scrape_quest_oripa.yml` runs this scraper automatically.

--- a/quest_oripa_scraper.py
+++ b/quest_oripa_scraper.py
@@ -1,0 +1,132 @@
+import os
+import base64
+import re
+from typing import List
+from urllib.parse import urljoin, urlparse
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "https://quest-oripa.com/"
+SPREADSHEET_URL = os.environ.get("SPREADSHEET_URL")
+SHEET_NAME = "その他"
+
+
+def save_credentials() -> str:
+    encoded = os.environ.get("GSHEET_JSON", "")
+    if not encoded:
+        raise RuntimeError("GSHEET_JSON environment variable is missing")
+    with open("credentials.json", "w") as f:
+        f.write(base64.b64decode(encoded).decode("utf-8"))
+    return "credentials.json"
+
+
+def get_sheet():
+    creds_path = save_credentials()
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    client = gspread.authorize(creds)
+    if not SPREADSHEET_URL:
+        raise RuntimeError("SPREADSHEET_URL environment variable is missing")
+    spreadsheet = client.open_by_url(SPREADSHEET_URL)
+    return spreadsheet.worksheet(SHEET_NAME)
+
+
+def normalize_url(url: str) -> str:
+    if not url:
+        return ""
+    parts = urlparse(url)
+    return f"{parts.scheme}://{parts.netloc}{parts.path}"
+
+
+def fetch_existing_urls(sheet) -> set:
+    records = sheet.get_all_values()
+    urls = set()
+    for row in records[1:]:
+        if len(row) >= 3:
+            u = row[2].strip()
+            if u:
+                urls.add(normalize_url(u))
+    return urls
+
+
+def parse_items(page) -> List[dict]:
+    return page.evaluate(
+        """
+        () => {
+            const results = [];
+            document.querySelectorAll('a.card-href').forEach(a => {
+                const img = a.querySelector('img');
+                const title = img ? (img.getAttribute('alt') || '').trim() : '';
+                const image = img ? (img.getAttribute('src') || '') : '';
+                const url = a.href || '';
+                const ptEl = a.querySelector('span.oripa-price');
+                let pt = '';
+                if (ptEl) pt = ptEl.textContent.replace(/\\s+/g, '');
+                results.push({title, image, url, pt});
+            });
+            return results;
+        }
+        """
+    )
+
+
+def scrape_items(existing_urls: set) -> List[List[str]]:
+    rows: List[List[str]] = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        page = browser.new_page()
+        print("🔍 quest-oripa.com スクレイピング開始...")
+        try:
+            page.goto(BASE_URL, timeout=60000, wait_until="networkidle")
+            page.wait_for_selector('a.card-href', timeout=60000)
+        except Exception as exc:
+            html = page.content()
+            browser.close()
+            with open("quest_oripa_debug.html", "w", encoding="utf-8") as f:
+                f.write(html)
+            print(f"🛑 ページ読み込み失敗: {exc}")
+            return rows
+
+        items = parse_items(page)
+        browser.close()
+
+    for item in items:
+        detail_url = item.get("url", "").strip()
+        image_url = item.get("image", "").strip()
+        title = item.get("title", "noname").strip() or "noname"
+        pt_text = re.sub(r"[^0-9,]", "", item.get("pt", ""))
+
+        if detail_url.startswith("/"):
+            detail_url = urljoin(BASE_URL, detail_url)
+        if image_url.startswith("/"):
+            image_url = urljoin(BASE_URL, image_url)
+
+        norm_url = normalize_url(detail_url)
+        if norm_url in existing_urls:
+            print(f"⏭ スキップ（重複）: {title}")
+            continue
+
+        rows.append([title, image_url, detail_url, pt_text])
+        existing_urls.add(norm_url)
+
+    return rows
+
+
+def main() -> None:
+    sheet = get_sheet()
+    existing_urls = fetch_existing_urls(sheet)
+    rows = scrape_items(existing_urls)
+    if rows:
+        sheet.append_rows(rows, value_input_option="USER_ENTERED")
+        print(f"📥 {len(rows)} 件追記完了")
+    else:
+        print("📭 新規データなし")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `quest_oripa_scraper.py` for scraping quest-oripa.com
- create workflow `scrape_quest_oripa.yml` to run scraper on schedule
- document Quest Oripa scraper in README

## Testing
- `python -m py_compile quest_oripa_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_6874560d4cec83239a4652e4bf141c8a