### PR TITLE
Add Pokepa365 banner scraper

### DIFF
--- a/.github/workflows/scrape_pokepa365_banner.yml
+++ b/.github/workflows/scrape_pokepa365_banner.yml
@@ -1,0 +1,30 @@
+name: Scrape Pokepa365 Banner
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m playwright install --with-deps
+
+      - name: Run banner scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+          SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
+        run: python pokepa365_banner_scraper.py

--- a/README.md
+++ b/README.md
@@ -542,6 +542,21 @@ python pokepa365_scraper.py
 
 The workflow `.github/workflows/scrape_pokepa365.yml` runs this scraper automatically.
 
+## Pokepa365 Banner Scraper
+
+The `pokepa365_banner_scraper.py` script retrieves banner image URLs from [pokepa365.com](https://pokepa365.com/index). It uses Playwright to cycle through the top page slider and appends the image URL and site URL to the `news` sheet while skipping duplicates.
+
+Run locally:
+
+```bash
+pip install -r requirements.txt
+export GSHEET_JSON=<BASE64_SERVICE_ACCOUNT_JSON>
+export SPREADSHEET_URL=<YOUR_SHEET_URL>
+python pokepa365_banner_scraper.py
+```
+
+The workflow `.github/workflows/scrape_pokepa365_banner.yml` runs this scraper automatically.
+
 ## Kagura TCG Scraper
 
 The `kagura_tcg_scraper.py` script collects gacha information from [kagura-tcg.com](https://kagura-tcg.com/). It uses Playwright to scrape the top page and gathers the title, image URL, detail page URL and PT value from each entry. New rows are appended to the `その他` sheet while skipping entries with duplicate URLs.

--- a/pokepa365_banner_scraper.py
+++ b/pokepa365_banner_scraper.py
@@ -1,0 +1,98 @@
+import base64
+import os
+from urllib.parse import urljoin
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "https://pokepa365.com"
+TARGET_URL = f"{BASE_URL}/index"
+SHEET_NAME = "news"
+SPREADSHEET_URL = os.environ.get("SPREADSHEET_URL")
+
+
+def save_credentials() -> str:
+    encoded = os.environ.get("GSHEET_JSON", "")
+    if not encoded:
+        raise RuntimeError("GSHEET_JSON environment variable is missing")
+    with open("credentials.json", "w") as f:
+        f.write(base64.b64decode(encoded).decode("utf-8"))
+    return "credentials.json"
+
+
+def get_sheet():
+    creds_path = save_credentials()
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    client = gspread.authorize(creds)
+    if not SPREADSHEET_URL:
+        raise RuntimeError("SPREADSHEET_URL environment variable is missing")
+    spreadsheet = client.open_by_url(SPREADSHEET_URL)
+    return spreadsheet.worksheet(SHEET_NAME)
+
+
+def fetch_existing_image_urls(sheet) -> set:
+    records = sheet.get_all_values()
+    return set(row[0].strip() for row in records[1:] if row and row[0].strip())
+
+
+def scrape_banners(existing_urls: set):
+    print("🔍 Playwright によるスクレイピング開始...")
+    rows = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        context = browser.new_context(
+            user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
+        )
+        page = context.new_page()
+
+        try:
+            page.goto(TARGET_URL, timeout=60000, wait_until="load")
+            page.wait_for_timeout(8000)
+
+            # click through the slider to ensure images load
+            dots = page.query_selector_all(".owl-dot")
+            next_btn = page.query_selector(".owl-next")
+            if next_btn:
+                for _ in range(len(dots) or 0):
+                    next_btn.click()
+                    page.wait_for_timeout(500)
+
+            images = page.query_selector_all(".owl-carousel img")
+            for img in images:
+                src = img.get_attribute("src")
+                if not src:
+                    continue
+                full_src = urljoin(BASE_URL, src)
+                full_href = BASE_URL  # B列には常に BASE_URL を出力
+                if full_src not in existing_urls:
+                    rows.append([full_src, full_href])
+                    existing_urls.add(full_src)
+
+        except Exception as e:
+            print(f"🛑 読み込み失敗: {e}")
+        finally:
+            browser.close()
+
+    print(f"✅ {len(rows)} 件の新規バナー")
+    return rows
+
+
+def main() -> None:
+    sheet = get_sheet()
+    existing = fetch_existing_image_urls(sheet)
+    rows = scrape_banners(existing)
+    if not rows:
+        print("📭 新規データなし")
+        return
+    sheet.append_rows(rows, value_input_option="USER_ENTERED")
+    print(f"📥 {len(rows)} 件追記完了")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add scraper script for pokepa365 banner images
- run scraper via new workflow
- document how to use the banner scraper in README

## Testing
- `python -m py_compile pokepa365_banner_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68771ae9d8f48323879ef56e22a6bebf