### PR TITLE
Add Victore scraper workflow

### DIFF
--- a/.github/workflows/scrape_victore.yml
+++ b/.github/workflows/scrape_victore.yml
@@ -1,0 +1,38 @@
+name: Scrape Victore
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */3 * * *'
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m playwright install --with-deps
+
+      - name: Run scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+          SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
+        run: python victore_scraper.py
+
+      - name: Upload debug HTML
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: victore_debug
+          path: victore_debug.html
+

--- a/victore_scraper.py
+++ b/victore_scraper.py
@@ -1,0 +1,120 @@
+import os
+import base64
+from typing import List
+from urllib.parse import urljoin
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "https://www.v-tr.net/victore#/"
+SHEET_NAME = "その他"
+SPREADSHEET_URL = os.environ.get("SPREADSHEET_URL")
+
+
+def save_credentials() -> str:
+    encoded = os.environ.get("GSHEET_JSON", "")
+    if not encoded:
+        raise RuntimeError("GSHEET_JSON environment variable is missing")
+    with open("credentials.json", "w") as f:
+        f.write(base64.b64decode(encoded).decode("utf-8"))
+    return "credentials.json"
+
+
+def get_sheet():
+    creds_path = save_credentials()
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    client = gspread.authorize(creds)
+    if not SPREADSHEET_URL:
+        raise RuntimeError("SPREADSHEET_URL environment variable is missing")
+    spreadsheet = client.open_by_url(SPREADSHEET_URL)
+    return spreadsheet.worksheet(SHEET_NAME)
+
+
+def fetch_existing_urls(sheet) -> set:
+    records = sheet.get_all_values()
+    urls = set()
+    for row in records[1:]:
+        if len(row) >= 3:
+            urls.add(row[2].strip())
+    return urls
+
+
+def scrape_victore(existing_urls: set) -> List[List[str]]:
+    rows: List[List[str]] = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        page = browser.new_page()
+        print("🔍 v-tr.net victore スクレイピング開始...")
+        try:
+            page.goto(BASE_URL, timeout=120000, wait_until="networkidle")
+            page.wait_for_selector("li.packs__list", timeout=60000)
+        except Exception as exc:
+            print(f"🛑 ページ読み込み失敗: {exc}")
+            html = page.content()
+            with open("victore_debug.html", "w", encoding="utf-8") as f:
+                f.write(html)
+            browser.close()
+            return rows
+
+        items = page.evaluate(
+            """
+            () => {
+                const results = [];
+                document.querySelectorAll('li.packs__list').forEach(li => {
+                    const img = li.querySelector('img');
+                    const title = img ? (img.getAttribute('alt') || '') : '';
+                    const image = img ? (img.getAttribute('src') || '') : '';
+                    const link = li.querySelector('a[href*="packdetail"]');
+                    const url = link ? (link.getAttribute('href') || '') : '';
+                    const ptEl = li.querySelector('.packs__detail--price');
+                    const pt = ptEl ? ptEl.textContent.trim() : '';
+                    results.push({ title, image, url, pt });
+                });
+                return results;
+            }
+            """
+        )
+        browser.close()
+
+    for item in items:
+        detail_url = item.get("url", "").strip()
+        image_url = item.get("image", "").strip()
+        title = item.get("title", "").strip() or "noname"
+        pt_text = item.get("pt", "").strip()
+
+        if detail_url.startswith("/") or detail_url.startswith("#"):
+            detail_url = urljoin("https://www.v-tr.net", detail_url)
+        if image_url.startswith("/"):
+            image_url = urljoin("https://www.v-tr.net", image_url)
+
+        if detail_url in existing_urls:
+            print(f"⏭ スキップ（重複）: {title}")
+            continue
+
+        rows.append([title, image_url, detail_url, pt_text])
+        existing_urls.add(detail_url)
+
+    return rows
+
+
+def main() -> None:
+    sheet = get_sheet()
+    existing_urls = fetch_existing_urls(sheet)
+    rows = scrape_victore(existing_urls)
+    if not rows:
+        print("📭 新規データなし")
+        return
+    try:
+        sheet.append_rows(rows, value_input_option="USER_ENTERED")
+        print(f"📥 {len(rows)} 件追記完了")
+    except Exception as exc:
+        print(f"❌ 書き込みエラー: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new `victore_scraper.py` using Playwright
- schedule Victore scraper in CI with `scrape_victore.yml`

## Testing
- `python -m py_compile victore_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68803858470083238eaf771399c41412