### PR TITLE
Add Oripark special offer scraper

### DIFF
--- a/.github/workflows/scrape_oripark.yml
+++ b/.github/workflows/scrape_oripark.yml
@@ -1,0 +1,36 @@
+name: Scrape Oripark Special Offer
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */3 * * *'
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements.txt
+          python -m playwright install
+
+      - name: Run Oripark scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+          SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
+        run: python oripark_scraper.py
+
+      - name: Upload debug HTML
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oripark_debug
+          path: oripark_debug.html

--- a/oripark_scraper.py
+++ b/oripark_scraper.py
@@ -1,0 +1,130 @@
+import os
+import base64
+from typing import List
+from urllib.parse import urljoin, urlparse
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "https://oripark.jp/special-offer"
+DOMAIN = "https://oripark.jp"
+SHEET_NAME = "その他"
+SPREADSHEET_URL = os.environ.get("SPREADSHEET_URL")
+
+
+def save_credentials() -> str:
+    encoded = os.environ.get("GSHEET_JSON", "")
+    if not encoded:
+        raise RuntimeError("GSHEET_JSON environment variable is missing")
+    with open("credentials.json", "w") as f:
+        f.write(base64.b64decode(encoded).decode("utf-8"))
+    return "credentials.json"
+
+
+def get_sheet():
+    creds_path = save_credentials()
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    client = gspread.authorize(creds)
+    if not SPREADSHEET_URL:
+        raise RuntimeError("SPREADSHEET_URL environment variable is missing")
+    spreadsheet = client.open_by_url(SPREADSHEET_URL)
+    return spreadsheet.worksheet(SHEET_NAME)
+
+
+def fetch_existing_urls(sheet) -> set:
+    records = sheet.get_all_values()
+    urls = set()
+    for row in records[1:]:
+        if len(row) >= 3:
+            url = row[2].strip()
+            if url:
+                p = urlparse(url)
+                urls.add(f"{p.scheme}://{p.netloc}{p.path}")
+    return urls
+
+
+def parse_items(page) -> List[dict]:
+    return page.evaluate(
+        """
+        () => {
+            const results = [];
+            document.querySelectorAll('div.gacha-item').forEach(item => {
+                const link = item.querySelector('a[href]');
+                const img = item.querySelector('img.card-img-top');
+                const price = item.querySelector('.gacha-price');
+                const title = img ? (img.getAttribute('alt') || '').trim() : '';
+                const image = img ? (img.getAttribute('src') || '') : '';
+                const url = link ? link.href : '';
+                const pt = price ? price.textContent.replace(/[^0-9]/g, '') : '';
+                results.push({ title, image, url, pt });
+            });
+            return results;
+        }
+        """
+    )
+
+
+def scrape_items(existing_urls: set) -> List[List[str]]:
+    rows: List[List[str]] = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        page = browser.new_page()
+        print("🔍 oripark.jp/special-offer スクレイピング開始...")
+        try:
+            page.goto(BASE_URL, timeout=60000, wait_until="networkidle")
+            page.wait_for_selector('div.gacha-item', timeout=60000)
+        except Exception as exc:
+            print(f"🛑 ページ読み込み失敗: {exc}")
+            html = page.content()
+            with open("oripark_debug.html", "w", encoding="utf-8") as f:
+                f.write(html)
+            browser.close()
+            return rows
+
+        items = parse_items(page)
+        browser.close()
+
+    for item in items:
+        detail_url = item.get("url", "").strip()
+        image_url = item.get("image", "").strip()
+        title = item.get("title", "noname").strip() or "noname"
+        pt_text = item.get("pt", "").strip()
+
+        if detail_url.startswith("/"):
+            detail_url = urljoin(DOMAIN, detail_url)
+        if image_url.startswith("/"):
+            image_url = urljoin(DOMAIN, image_url)
+
+        parsed = urlparse(detail_url)
+        norm_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+
+        if norm_url in existing_urls:
+            print(f"⏭ スキップ（重複）: {title}")
+            continue
+
+        rows.append([title, image_url, detail_url, pt_text])
+        existing_urls.add(norm_url)
+    return rows
+
+
+def main() -> None:
+    sheet = get_sheet()
+    existing_urls = fetch_existing_urls(sheet)
+    rows = scrape_items(existing_urls)
+    if not rows:
+        print("📭 新規データなし")
+        return
+    try:
+        sheet.append_rows(rows, value_input_option="USER_ENTERED")
+        print(f"📥 {len(rows)} 件追記完了")
+    except Exception as exc:
+        print(f"❌ スプレッドシート書き込み失敗: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scrape oripark.jp special offers with Playwright and append title, image, URL, and PT to the "その他" sheet while skipping existing URLs
- add scheduled workflow to run the new scraper

## Testing
- `python -m py_compile oripark_scraper.py`
- `python oripark_scraper.py` *(fails: RuntimeError: GSHEET_JSON environment variable is missing)*
- `python -m playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_6897666f9f788323a71fd32355f9d267