### PR TITLE
Add TorecaTokyo gacha scraper and workflow

### DIFF
--- a/.github/workflows/scrape_torecatokyo.yml
+++ b/.github/workflows/scrape_torecatokyo.yml
@@ -1,0 +1,37 @@
+name: Scrape Torecatokyo
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */3 * * *'
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m playwright install --with-deps
+
+      - name: Run scraper
+        env:
+          GSHEET_JSON: ${{ secrets.GSHEET_JSON }}
+          SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
+        run: python torecatokyo_scraper.py
+
+      - name: Upload debug HTML
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: torecatokyo_debug
+          path: torecatokyo_debug.html

--- a/torecatokyo_scraper.py
+++ b/torecatokyo_scraper.py
@@ -1,0 +1,137 @@
+import os
+import base64
+import re
+from typing import List
+from urllib.parse import urljoin, urlparse
+
+import gspread
+from google.oauth2.service_account import Credentials
+from playwright.sync_api import sync_playwright
+
+BASE_URL = "https://torecatokyo.com"
+TARGET_URL = "https://torecatokyo.com/gacha/"
+SHEET_NAME = "その他"
+
+
+def save_credentials() -> str:
+    encoded = os.environ.get("GSHEET_JSON", "")
+    if not encoded:
+        raise RuntimeError("GSHEET_JSON environment variable is missing")
+    with open("credentials.json", "w") as f:
+        f.write(base64.b64decode(encoded).decode("utf-8"))
+    return "credentials.json"
+
+
+def get_sheet():
+    creds_path = save_credentials()
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    client = gspread.authorize(creds)
+    spreadsheet_url = os.environ.get("SPREADSHEET_URL")
+    if not spreadsheet_url:
+        raise RuntimeError("SPREADSHEET_URL environment variable is missing")
+    spreadsheet = client.open_by_url(spreadsheet_url)
+    return spreadsheet.worksheet(SHEET_NAME)
+
+
+def normalize_url(url: str) -> str:
+    parts = urlparse(url)
+    return f"{parts.scheme}://{parts.netloc}{parts.path}"
+
+
+def fetch_existing_urls(sheet) -> set:
+    records = sheet.get_all_values()
+    urls = set()
+    for row in records[1:]:
+        if len(row) >= 3:
+            url = row[2].strip()
+            if url:
+                urls.add(normalize_url(url))
+    return urls
+
+
+def parse_items(page) -> List[dict]:
+    js = """
+    () => {
+        const results = [];
+        document.querySelectorAll('li.gacha_list_card').forEach(li => {
+            const a = li.querySelector('a.gacha_eyecatch');
+            const url = a ? a.href : '';
+            let image = '';
+            let title = '';
+            if (a) {
+                const img = a.querySelector('img');
+                if (img) {
+                    image = img.getAttribute('src') || '';
+                    title = img.getAttribute('alt') || '';
+                }
+            }
+            const ptEl = li.querySelector('.gacha_list_mater_points strong');
+            const pt = ptEl ? ptEl.textContent.trim() : '';
+            results.push({ title, image, url, pt });
+        });
+        return results;
+    }
+    """
+    return page.evaluate(js)
+
+
+def scrape_items(existing_urls: set) -> List[List[str]]:
+    rows: List[List[str]] = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        page = browser.new_page()
+        print("🔍 torecatokyo.com スクレイピング開始...")
+        try:
+            page.goto(TARGET_URL, timeout=60000, wait_until="networkidle")
+            page.wait_for_selector('li.gacha_list_card', timeout=60000)
+        except Exception as exc:
+            print(f"🛑 ページ読み込み失敗: {exc}")
+            html = page.content()
+            with open('torecatokyo_debug.html', 'w', encoding='utf-8') as f:
+                f.write(html)
+            browser.close()
+            return rows
+
+        items = parse_items(page)
+        browser.close()
+
+    for item in items:
+        detail_url = item.get("url", "").strip()
+        image_url = item.get("image", "").strip()
+        title = item.get("title", "").strip() or "noname"
+        pt_text = item.get("pt", "")
+        pt_value = re.sub(r"[^0-9]", "", pt_text)
+
+        if detail_url.startswith('/'):
+            detail_url = urljoin(BASE_URL, detail_url)
+        if image_url.startswith('/'):
+            image_url = urljoin(BASE_URL, image_url)
+
+        norm_url = normalize_url(detail_url)
+        if not detail_url or norm_url in existing_urls:
+            print(f"⏭ スキップ（重複）: {title}")
+            continue
+
+        rows.append([title, image_url, detail_url, pt_value])
+        existing_urls.add(norm_url)
+
+    return rows
+
+
+def main() -> None:
+    sheet = get_sheet()
+    existing_urls = fetch_existing_urls(sheet)
+    rows = scrape_items(existing_urls)
+    if rows:
+        sheet.append_rows(rows, value_input_option="USER_ENTERED")
+        print(f"📥 {len(rows)} 件追記完了")
+    else:
+        print("📭 新規データなし")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Playwright scraper for torecatokyo.com gacha items storing title, image URL, page URL and PT in the 'その他' sheet
- create scheduled GitHub Action to run the new scraper

## Testing
- `python -m py_compile torecatokyo_scraper.py`
- `GSHEET_JSON='e30=' SPREADSHEET_URL='https://example.com' python torecatokyo_scraper.py` *(fails: Service account info was not in the expected format)*

------
https://chatgpt.com/codex/tasks/task_e_68976c6335488323a1938e7429e33743