### PR TITLE
fix: update oripaone scraper selectors

### DIFF
--- a/scrape_oripaone_to_sheets.py
+++ b/scrape_oripaone_to_sheets.py
@@ -41,7 +41,9 @@ driver.get("https://oripaone.jp/")
 
 try:
     WebDriverWait(driver, 15).until(
-        EC.presence_of_element_located((By.CSS_SELECTOR, "div.relative.overflow-hidden.rounded.bg-white.shadow"))
+        EC.presence_of_element_located(
+            (By.CSS_SELECTOR, "div.relative.overflow-hidden.bg-white.shadow")
+        )
     )
 except:
     print("❌ 要素が読み込まれませんでした。")
@@ -50,7 +52,7 @@ except:
 
 # --- HTML取得とパース ---
 soup = BeautifulSoup(driver.page_source, "html.parser")
-cards = soup.select("div.relative.overflow-hidden.rounded.bg-white.shadow")
+cards = soup.select("div.relative.overflow-hidden.bg-white.shadow")
 
 results = []
 for card in cards:


### PR DESCRIPTION
## Summary
- fix oripaone scraper by adjusting CSS selectors for updated site markup

## Testing
- `python -m py_compile scrape_oripaone_to_sheets.py`
- `python scrape_oripaone_to_sheets.py` *(fails: Could not deserialize key data)*

------
https://chatgpt.com/codex/tasks/task_e_689ff723e2c8832391bbf820ee61948d