### PR TITLE
Fix orikuji scraper timeout

### DIFF
--- a/orikuji_scraper.py
+++ b/orikuji_scraper.py
@@ -52,7 +52,11 @@ def scrape_orikuji(existing_paths: set) -> List[List[str]]:
         print("🔍 orikuji.com スクレイピング開始...")
 
         try:
-            page.goto(BASE_URL, timeout=60000, wait_until="networkidle")
+            # The site continuously opens network connections which prevents
+            # Playwright from reaching a "networkidle" state and results in a
+            # timeout. Waiting for the DOM content instead is sufficient for
+            # scraping the required elements.
+            page.goto(BASE_URL, timeout=60000, wait_until="domcontentloaded")
 
             # 強化: すべてのwhite-boxを順番にscrollIntoViewして仮想リスト系の要素も表示させる
             def scroll_to_load_all(page, selector="div.white-box", max_tries=30):


### PR DESCRIPTION
## Summary
- avoid networkidle wait when loading orikuji.com by waiting for DOM content instead

## Testing
- `playwright install chromium` *(fails: server returned code 403)*
- `python - <<'PY' from orikuji_scraper import scrape_orikuji` *(fails: BrowserType.launch executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a02ed37c8323b5a709ce90d90511