### PR TITLE
Fix orikuji scraper timeout

### DIFF
--- a/orikuji_scraper.py
+++ b/orikuji_scraper.py
@@ -52,25 +52,42 @@ def scrape_orikuji(existing_paths: set) -> List[List[str]]:
         print("🔍 orikuji.com スクレイピング開始...")
 
         try:
-            page.goto(BASE_URL, timeout=60000, wait_until="networkidle")
+            # The site continuously opens network connections which prevents
+            # Playwright from reaching a "networkidle" state and results in a
+            # timeout. Waiting for the DOM content instead is sufficient for
+            # scraping the required elements.
+            page.goto(BASE_URL, timeout=60000, wait_until="domcontentloaded")
 
-            # 強化: すべてのwhite-boxを順番にscrollIntoViewして仮想リスト系の要素も表示させる
-            def scroll_to_load_all(page, selector="div.white-box", max_tries=30):
-                prev_count = 0
-                for i in range(max_tries):
-                    boxes = page.query_selector_all(selector)
-                    for box in boxes:
-                        try:
-                            box.scroll_into_view_if_needed()
-                            page.wait_for_timeout(150)
-                        except Exception:
-                            pass
+            # Scroll to the bottom repeatedly so that the site loads all
+            # available gacha boxes (the page uses infinite scroll). Some
+            # content is injected asynchronously after the initial page load,
+            # so wait for at least one box to appear before starting the
+            # scrolling loop.
+            def scroll_to_bottom(page, selector="div.white-box", max_scrolls=50, pause_ms=500):
+                page.wait_for_selector(selector, timeout=60000)
+                last_count = 0
+                stagnant = 0
+                for _ in range(max_scrolls):
+                    page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+                    page.wait_for_timeout(pause_ms)
+                    try:
+                        load_more = page.query_selector("button:has-text('もっと見る')")
+                        if load_more:
+                            load_more.click()
+                            page.wait_for_timeout(pause_ms)
+                    except Exception:
+                        pass
                     curr_count = len(page.query_selector_all(selector))
-                    if curr_count == prev_count:
-                        break
-                    prev_count = curr_count
-                print(f"👀 {curr_count}件の {selector} を検出")
-            scroll_to_load_all(page)
+                    if curr_count == last_count:
+                        stagnant += 1
+                        if stagnant >= 2:
+                            break
+                    else:
+                        stagnant = 0
+                    last_count = curr_count
+                print(f"👀 {last_count}件の {selector} を検出")
+
+            scroll_to_bottom(page)
 
             page.wait_for_selector("div.white-box img", timeout=60000)
 
@@ -92,7 +109,8 @@ def scrape_orikuji(existing_paths: set) -> List[List[str]]:
                         const image = imgSrc;
                         const url = link.getAttribute('href') || '';
                         const ptEl = box.querySelector('span.coin-area');
-                        const pt = ptEl ? ptEl.textContent.trim() : '';
+                        const rawPt = ptEl ? ptEl.textContent : '';
+                        const pt = rawPt.replace(/\D/g, '');
                         results.push({ title, image, url, pt });
                     });
                     return results;


### PR DESCRIPTION
## Summary
- avoid networkidle wait when loading orikuji.com by waiting for DOM content instead
- normalize point values by removing non-digit characters from coin counts
- scroll to the page bottom and click 「もっと見る」 when present so all gacha boxes are collected
- wait for gacha boxes to appear and keep scrolling until counts stabilize so the full list is loaded

## Testing
- `python -m py_compile orikuji_scraper.py`
- `playwright install chromium` *(fails: server returned code 403)*
- `python - <<'PY'
from orikuji_scraper import scrape_orikuji
rows = scrape_orikuji(set())
print('rows len', len(rows))
PY` *(fails: BrowserType.launch executable doesn't exist)*
- `python orikuji_scraper.py` *(fails: GSHEET_JSON environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a02ed37c8323b5a709ce90d90511