### PR TITLE
Fix oripalette scraper for updated site

### DIFF
--- a/oripalette_scraper.py
+++ b/oripalette_scraper.py
@@ -73,7 +73,7 @@ def parse_items(page) -> List[dict]:
             const results = [];
             document.querySelectorAll('div.banner_base.banner').forEach(box => {
                 const img = box.querySelector('img.current') || box.querySelector('img');
-                const image = img ? (img.getAttribute('src') || '') : '';
+                const image = img ? (img.getAttribute('data-src') || img.getAttribute('src') || '') : '';
                 let title = img ? (img.getAttribute('alt') || img.getAttribute('title') || '').trim() : '';
                 if (!title) {
                     const tEl = box.querySelector('.name_area-info') || box.querySelector('.name_area');
@@ -83,8 +83,11 @@ def parse_items(page) -> List[dict]:
                 const a = box.querySelector('a[href]');
                 if (a) url = a.getAttribute('href') || '';
                 if (!url) {
-                    const m = image.match(/\/pack\/(\d+)/);
-                    if (m) url = `/pack/${m[1]}`;
+                    const m = image.match(/\/(pack|gacha)\/(\d+)/);
+                    if (m) {
+                        const prefix = m[1] === 'gacha' ? '/gacha' : '/pack';
+                        url = `${prefix}/${m[2]}`;
+                    }
                 }
                 let pt = '';
                 const ptEl = box.querySelector('.point') || box.querySelector('.point_area') || box.querySelector('div.point');
@@ -132,6 +135,9 @@ def scrape_items(existing_urls: set) -> List[List[str]]:
             if image_url.startswith("/"):
                 image_url = urljoin(BASE_URL, image_url)
 
+            # Skip entries where URL could not be determined
+            if not detail_url:
+                continue
             if detail_url in existing_urls:
                 continue
 


### PR DESCRIPTION
## Summary
- handle new image and URL patterns on oripalette banners
- skip banners without a resolvable detail URL to avoid blank entries

## Testing
- `python -m py_compile oripalette_scraper.py`
- ⚠️ `playwright install chromium` (network 403)


------
https://chatgpt.com/codex/tasks/task_e_68c69addede48323950810899372a6d2